### PR TITLE
Normalize storage kind option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ yarn add @BolajiOlajide/now-playing
 import {
   NowPlaying,
   Providers,
-  StorageKinds,
 } from "@BolajiOlajide/now-playing";
 
 const np = new NowPlaying(Providers.SPOTIFY, {
-  storageKind: StorageKinds.INMEMORY,
   useCache: false, // default is true
   cacheDuration: 30000, // in milliseconds
   streamerArgs: {
@@ -48,7 +46,7 @@ const np = new NowPlaying(Providers.SPOTIFY, {
 
 You need two things.
 
-1. Spotify Client ID 
+1. Spotify Client ID
 2. Spotify Client Secret
 2. Spotify Refresh Token
 

--- a/examples/spotify.ts
+++ b/examples/spotify.ts
@@ -1,7 +1,6 @@
-import { NowPlaying, Providers, StorageKinds } from "../dist";
+import { NowPlaying, Providers } from "../dist";
 
 const np = new NowPlaying(Providers.SPOTIFY, {
-  storageKind: StorageKinds.INMEMORY,
   streamerArgs: {
     clientId: 'foo',
     clientSecret: 'bar',

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,7 @@
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.message = `ValidationError: ${message}`
+    this.name = 'ValidationError'
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { NowPlaying } from './main'
-export { StorageKinds, Providers } from './schema'
+export {  Providers } from './schema'

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,6 @@ import { ZodError } from 'zod'
 
 import { CACHE_DURATION_MS } from './constants'
 import {
-  type StorageKind,
-  StorageKinds,
   providerSchema,
   Providers,
   type NoopProviderArgs,
@@ -20,7 +18,6 @@ import { ValidationError } from './error'
 // user.
 export class NowPlaying {
   private provider: Providers
-  private storageKind: StorageKind
   private useCache: boolean
   private cacheDuration: number
   private storer: IStorer
@@ -39,12 +36,12 @@ export class NowPlaying {
 
       this.parseArgs(args)
       this.streamerArgs = args.streamerArgs
-      this.storageKind = args.storageKind || StorageKinds.INMEMORY
       this.useCache = args.useCache || true
       this.cacheDuration = args.cacheDuration || CACHE_DURATION_MS;
 
-      // this is whatever storage mechanic the user selects
-      this.storer = this.getStorer(this.storageKind)
+      // We only support in memory storage for now, if there's a need we can
+      // support more storage mechanism.
+      this.storer = this.getStorer()
       this.streamer = this.getStreamer()
     } catch (err: unknown) {
       if (err instanceof ZodError) {
@@ -70,13 +67,8 @@ export class NowPlaying {
     }
   }
 
-  private getStorer(storageKind: StorageKind): IStorer {
-    switch (storageKind) {
-      case StorageKinds.INMEMORY:
-        return new InMemoryStorage()
-      default:
-        throw new Error('unsupported storage kind')
-    }
+  private getStorer(): IStorer {
+    return new InMemoryStorage()
   }
 
   private getStreamer(): IStreamer {

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,9 +72,10 @@ export class NowPlaying {
   }
 
   private getStreamer(): IStreamer {
+    const cacheOpts = { useCache: this.useCache, cacheDuration: this.cacheDuration }
     switch (this.provider) {
       case Providers.SPOTIFY:
-        return new SpotifyStreamer(this.storer, { ...this.streamerArgs as SpotifyStreamerArgs })
+        return new SpotifyStreamer(this.storer, { ...this.streamerArgs as SpotifyStreamerArgs, ...cacheOpts })
       case Providers.NOOP:
         return new NoopStreamer()
       default:
@@ -83,6 +84,6 @@ export class NowPlaying {
   }
 
   fetchCurrentlyPlayingOrLastPlayed(): Promise<Song | null> {
-    return this.streamer.fetchCurrentlyPlaying(this.useCache, this.cacheDuration)
+    return this.streamer.fetchCurrentlyPlaying()
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,15 +37,15 @@ export class NowPlaying {
       providerSchema.parse(provider)
       this.provider = provider
 
-    this.parseArgs(args)
-    this.streamerArgs = args.streamerArgs
-    this.storageKind = args.storageKind || StorageKinds.INMEMORY
-    this.useCache = args.useCache || true
-    this.cacheDuration = args.cacheDuration || CACHE_DURATION_MS;
+      this.parseArgs(args)
+      this.streamerArgs = args.streamerArgs
+      this.storageKind = args.storageKind || StorageKinds.INMEMORY
+      this.useCache = args.useCache || true
+      this.cacheDuration = args.cacheDuration || CACHE_DURATION_MS;
 
-    // this is whatever storage mechanic the user selects
-    this.storer = this.getStorer(this.storageKind)
-    this.streamer = this.getStreamer()
+      // this is whatever storage mechanic the user selects
+      this.storer = this.getStorer(this.storageKind)
+      this.streamer = this.getStreamer()
     } catch (err: unknown) {
       if (err instanceof ZodError) {
         // We want to display Zod errors one at a time, so we stick

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import { ZodError } from 'zod'
+
 import { CACHE_DURATION_MS } from './constants'
 import {
   type StorageKind,
@@ -12,6 +14,7 @@ import {
 } from './schema'
 import { InMemoryStorage, type IStorer } from './storage'
 import { SpotifyStreamer, NoopStreamer, type IStreamer, Song } from './streamers'
+import { ValidationError } from './error'
 
 // NowPlaying allows one to get the currently playing song for a streaming platform
 // user.
@@ -29,9 +32,10 @@ export class NowPlaying {
     provider: Providers,
     args: SpotifyProviderArgs | NoopProviderArgs
   ) {
-    // use zod to guarantee we get the right variable kind in here
-    providerSchema.parse(provider)
-    this.provider = provider
+    try {
+      // use zod to guarantee we get the right variable kind in here
+      providerSchema.parse(provider)
+      this.provider = provider
 
     this.parseArgs(args)
     this.streamerArgs = args.streamerArgs
@@ -42,6 +46,15 @@ export class NowPlaying {
     // this is whatever storage mechanic the user selects
     this.storer = this.getStorer(this.storageKind)
     this.streamer = this.getStreamer()
+    } catch (err: unknown) {
+      if (err instanceof ZodError) {
+        // We want to display Zod errors one at a time, so we stick
+        // to a similar format for returning errors.
+        const [firstError] = err.errors
+        throw new ValidationError(firstError.message)
+      }
+      throw new Error((err as Error)?.message)
+    }
   }
 
   private parseArgs(args: unknown): void {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -6,18 +6,8 @@ export enum Providers {
 }
 
 export const providerSchema = z.nativeEnum(Providers);
-// export type Provider = z.infer<typeof providerSchema>;
-
-export const StorageKinds = {
-  INMEMORY: "INMEMORY",
-  // SQLITE: 'SQLITE',
-} as const;
-
-export const storageKindSchema = z.nativeEnum(StorageKinds);
-export type StorageKind = z.infer<typeof storageKindSchema>;
 
 export const BaseNowPlayingArgsSchema = z.object({
-  storageKind: storageKindSchema.optional(),
   useCache: z.boolean().optional(),
   cacheDuration: z
     .number()

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,2 +1,2 @@
 export { InMemoryStorage } from './inmemory.storage'
-export type { IStorer, DataEntry } from './types'
+export type { IStorer, CacheDate } from './types'

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,2 +1,2 @@
 export { InMemoryStorage } from './inmemory.storage'
-export type { IStorer, CacheDate } from './types'
+export type { IStorer, CacheData } from './types'

--- a/src/storage/inmemory.storage.ts
+++ b/src/storage/inmemory.storage.ts
@@ -1,10 +1,10 @@
-import type { IStorer, DataEntry } from "./types";
+import type { IStorer, CacheDate } from "./types";
 
 export class InMemoryStorage implements IStorer {
-  private data: Map<string, DataEntry<unknown>> = new Map();
+  private data: Map<string, CacheDate<unknown>> = new Map();
 
-  set<T>(key: string, value: T, duration?: number): void {
-    const expiresAt = duration ? Date.now() + duration : Infinity;
+  set<T>(key: string, value: T, duration: number): void {
+    const expiresAt = Date.now() + duration;
 
     this.data.set(key, {
       value,
@@ -57,7 +57,7 @@ export class InMemoryStorage implements IStorer {
     }
   }
 
-  private entryIsStillValid(entry: DataEntry<unknown>): boolean {
-    return entry.expiresAt > Date.now() || entry.expiresAt === Infinity;
+  private entryIsStillValid(entry: CacheDate<unknown>): boolean {
+    return entry.expiresAt > Date.now();
   }
 }

--- a/src/storage/inmemory.storage.ts
+++ b/src/storage/inmemory.storage.ts
@@ -1,7 +1,7 @@
-import type { IStorer, CacheDate } from "./types";
+import type { IStorer, CacheData } from "./types";
 
 export class InMemoryStorage implements IStorer {
-  private data: Map<string, CacheDate<unknown>> = new Map();
+  private data: Map<string, CacheData<unknown>> = new Map();
 
   set<T>(key: string, value: T, duration: number): void {
     const expiresAt = Date.now() + duration;
@@ -57,7 +57,7 @@ export class InMemoryStorage implements IStorer {
     }
   }
 
-  private entryIsStillValid(entry: CacheDate<unknown>): boolean {
+  private entryIsStillValid(entry: CacheData<unknown>): boolean {
     return entry.expiresAt > Date.now();
   }
 }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -7,7 +7,7 @@ export interface IStorer {
   pruneExpiredEntries(): void;
 }
 
-export interface CacheDate<T> {
+export interface CacheData<T> {
   value: T;
   expiresAt: number;
 }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,5 +1,5 @@
 export interface IStorer {
-  set<T>(key: string, value: T, duration?: number): void;
+  set<T>(key: string, value: T, duration: number): void;
   get<T>(key: string): T | undefined;
   delete(key: string): boolean;
   has(key: string): boolean;

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -7,7 +7,7 @@ export interface IStorer {
   pruneExpiredEntries(): void;
 }
 
-export interface DataEntry<T> {
+export interface CacheDate<T> {
   value: T;
   expiresAt: number;
 }

--- a/src/streamers/spotify.streamer.ts
+++ b/src/streamers/spotify.streamer.ts
@@ -63,7 +63,7 @@ export class SpotifyStreamer implements IStreamer {
 
     const response: Response = await fetch('https://accounts.spotify.com/api/token', { method: 'POST', headers, body: params });
     const jsonData = await response.json() as SpotifyAccessToken;
-    this.storer.set(SPOTIFY_ACCESS_TOKEN_KEY, jsonData);
+    this.storer.set(SPOTIFY_ACCESS_TOKEN_KEY, jsonData, jsonData.expires_in - 1000);
     return jsonData;
   }
 
@@ -108,7 +108,9 @@ export class SpotifyStreamer implements IStreamer {
       url: track.external_urls.spotify,
     };
 
-    this.storer.set(SPOTIFY_TRACK_KEY, song, cacheDuration);
+    if (useCache) {
+      this.storer.set(SPOTIFY_TRACK_KEY, song, cacheDuration);
+    }
     return song;
   }
 

--- a/src/streamers/spotify.streamer.ts
+++ b/src/streamers/spotify.streamer.ts
@@ -1,6 +1,6 @@
 import fetch, { Response } from 'node-fetch';
 
-import type { Song, IStreamer } from './types';
+import type { Song, IStreamer, IStreamerCacheOpts } from './types';
 import { SpotifyStreamerArgsSchema, type SpotifyStreamerArgs } from '../schema';
 import type { IStorer } from '../storage';
 import { SPOTIFY_ACCESS_TOKEN_KEY, SPOTIFY_TRACK_KEY } from '../constants';
@@ -37,14 +37,18 @@ export class SpotifyStreamer implements IStreamer {
   private clientSecret: string;
   private refreshToken: string;
   private storer: IStorer;
+  private useCache: boolean;
+  private cacheDuration: number;
 
-  constructor(storer: IStorer, args: SpotifyStreamerArgs) {
+  constructor(storer: IStorer, args: SpotifyStreamerArgs & IStreamerCacheOpts) {
     this.storer = storer;
     SpotifyStreamerArgsSchema.parse(args);
 
     this.clientId = args.clientId;
     this.clientSecret = args.clientSecret;
     this.refreshToken = args.refreshToken;
+    this.useCache = args.useCache;
+    this.cacheDuration = args.cacheDuration;
   }
 
   public async getAccessToken(refreshToken: string, forceRefresh: boolean = false): Promise<SpotifyAccessToken> {
@@ -67,8 +71,8 @@ export class SpotifyStreamer implements IStreamer {
     return jsonData;
   }
 
-  public async fetchCurrentlyPlaying(useCache: boolean, cacheDuration: number): Promise<Song | null> {
-    if (useCache) {
+  public async fetchCurrentlyPlaying(): Promise<Song | null> {
+    if (this.useCache) {
       const cachedSong = this.storer.get<Song>(SPOTIFY_TRACK_KEY);
 
       if (cachedSong) {
@@ -88,13 +92,13 @@ export class SpotifyStreamer implements IStreamer {
     }
 
     if (response.status === 204 || !response.ok) {
-      return this.fetchLastPlayed(accessToken, useCache, cacheDuration);
+      return this.fetchLastPlayed(accessToken);
     }
 
     const jsonData = await response.json() as SpotifyCurrrentlyPlayingResponse;
 
     if (!jsonData.is_playing || jsonData.currently_playing_type !== 'track') {
-      return this.fetchLastPlayed(accessToken, useCache, cacheDuration);
+      return this.fetchLastPlayed(accessToken);
     }
 
     const track = jsonData.item;
@@ -108,13 +112,13 @@ export class SpotifyStreamer implements IStreamer {
       url: track.external_urls.spotify,
     };
 
-    if (useCache) {
-      this.storer.set(SPOTIFY_TRACK_KEY, song, cacheDuration);
+    if (this.useCache) {
+      this.storer.set(SPOTIFY_TRACK_KEY, song, this.cacheDuration);
     }
     return song;
   }
 
-  private async fetchLastPlayed(accessToken: SpotifyAccessToken, useCache: boolean, cacheDuration: number): Promise<Song | null> {
+  private async fetchLastPlayed(accessToken: SpotifyAccessToken): Promise<Song | null> {
     const headers = { Authorization: `Bearer ${accessToken.access_token}`, 'Content-Type': 'application/json', Accept: 'application/json' };
     const response: Response = await fetch('https://api.spotify.com/v1/me/player/recently-played?limit=1', { method: 'GET', headers });
     const jsonData = await response.json() as SpotifyRecentlyPlayedResponse;
@@ -133,8 +137,8 @@ export class SpotifyStreamer implements IStreamer {
       url: lastPlayedTrack.external_urls.spotify,
     };
 
-    if (useCache) {
-      this.storer.set(SPOTIFY_TRACK_KEY, lastPlayed, cacheDuration);
+    if (this.useCache) {
+      this.storer.set(SPOTIFY_TRACK_KEY, lastPlayed, this.cacheDuration);
     }
 
     return lastPlayed;

--- a/src/streamers/spotify.streamer.ts
+++ b/src/streamers/spotify.streamer.ts
@@ -67,7 +67,7 @@ export class SpotifyStreamer implements IStreamer {
     return jsonData;
   }
 
-  public async fetchCurrentlyPlaying(useCache: boolean = true, cacheDuration: number): Promise<Song | null> {
+  public async fetchCurrentlyPlaying(useCache: boolean, cacheDuration: number): Promise<Song | null> {
     if (useCache) {
       const cachedSong = this.storer.get<Song>(SPOTIFY_TRACK_KEY);
 

--- a/src/streamers/types.ts
+++ b/src/streamers/types.ts
@@ -1,8 +1,10 @@
 export interface IStreamer {
-  fetchCurrentlyPlaying(
-    useCache: boolean,
-    cacheDuration: number
-  ): Promise<Song | null>;
+  fetchCurrentlyPlaying(): Promise<Song | null>;
+}
+
+export interface IStreamerCacheOpts {
+  useCache: boolean;
+  cacheDuration: number;
 }
 
 export interface Song {


### PR DESCRIPTION
Currently, we have the option to specify storage kind but we only support in memory storage today.
I'm removing the option because I do not think we'd support other storage mechanisms in the future, instead what we can do is expose the `IStorer` interface and allow people to provide their own storage mechanism if they don't want to use ours.

That way the library is as flexible as can be.
Thoughts @lilpolymath ?

This PR shouldn't be merged before #5 as it includes changes from that PR.